### PR TITLE
Use only production deployments by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Replace `[repo]` with the repository name.
 | Parameter | Types                                                                           | Description                             | Example                                                                       |
 | --------- | ------------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------- |
 | style     | Default: `flat`<br>Available: `flat`, `flat-square`, `for-the-badge`, `plastic` | Select the visual style for your badge. | `https://vercelbadge.vercel.app/api/datejer/vercel-badge?style=for-the-badge` |
+| previews     | Default: `false`<br>Available: `false`, `true` | Use preview deployments for your badhe. | `https://vercelbadge.vercel.app/api/datejer/vercel-badge?previews=true` |
 
 ## Examples
 

--- a/api/[owner]/[repo].ts
+++ b/api/[owner]/[repo].ts
@@ -27,6 +27,10 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
   )
     style = req.query.style;
 
+  let previews;
+  if (!req.query.previews) previews = "false";
+  else previews = req.query.previews;
+
   axios
     .get(`https://api.github.com/repos/${owner}/${repo}/deployments`, {
       headers: {
@@ -45,11 +49,15 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
           .pipe(res);
       }
 
+      console.log(typeof req.query.previews)
+      console.log(previews)
+
       const vercelDeployments = response.data.filter(
         (deployment) =>
           deployment.creator.login === "vercel[bot]" &&
           deployment.creator.html_url === "https://github.com/apps/vercel" &&
-          deployment.creator.type === "Bot"
+          deployment.creator.type === "Bot" &&
+          (previews === "true" || deployment.environment === "Production")
       );
 
       if (vercelDeployments.length <= 0) {

--- a/api/[owner]/[repo].ts
+++ b/api/[owner]/[repo].ts
@@ -49,9 +49,6 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
           .pipe(res);
       }
 
-      console.log(typeof req.query.previews)
-      console.log(previews)
-
       const vercelDeployments = response.data.filter(
         (deployment) =>
           deployment.creator.login === "vercel[bot]" &&

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,6 @@
     "api/[owner]/[repo].ts": {
       "includeFiles": "assets/**"
     }
-  }
+  },
+  "trailingSlash": false
 }


### PR DESCRIPTION
Hi Artur,
By default you use show the status of the last deployment. If it’s a failed preview, that’s usually okay for the project.

In this PR I excluded preview deployments from the badge by default. Now the badge show status of the last production deployment. I also added and documented query parameter to include preview developments.

**Example**
Failed preview: 
https://badge.qurle.net/api/qurle/vercel-badge?previews=true 
![Should be red](https://badge.qurle.net/api/qurle/vercel-badge?previews=true)

Okay production: 
https://badge.qurle.net/api/qurle/vercel-badge
![Should be green](https://badge.qurle.net/api/qurle/vercel-badge)